### PR TITLE
feat: Support compiling for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-/.build
+.build
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/MacResources/Package.swift
+++ b/MacResources/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MacResources",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .library(
+            name: "SelectableCollectionViewMacResources",
+            targets: ["SelectableCollectionViewMacResources"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "SelectableCollectionViewMacResources",
+            resources: [.process("Resources")]
+        ),
+    ]
+)

--- a/MacResources/Sources/SelectableCollectionViewMacResources/Resources.swift
+++ b/MacResources/Sources/SelectableCollectionViewMacResources/Resources.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct Resources {
+
+    static public let bundle: Bundle = .module
+
+}

--- a/MacResources/Sources/SelectableCollectionViewMacResources/Resources/ShortcutItemView.xib
+++ b/MacResources/Sources/SelectableCollectionViewMacResources/Resources/ShortcutItemView.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21223" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21223"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "cassowaryswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tribalworldwidelondon/CassowarySwift.git",
+      "state" : {
+        "revision" : "7de8fee8331ad13eabb8de639fab0fde7a8f0d77",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "interact",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inseven/interact.git",
+      "state" : {
+        "revision" : "984649de2d454c95ebb9a65e5109e4de1afe00ba",
+        "version" : "2.19.11"
+      }
+    },
+    {
+      "identity" : "licensable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inseven/licensable",
+      "state" : {
+        "revision" : "a8ad62c6fde5aca29a47459b0687e580eee203dd",
+        "version" : "0.0.13"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "SelectableCollectionView",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v13),
+        .iOS(.v16)
     ],
     products: [
         .library(
@@ -14,13 +15,21 @@ let package = Package(
             targets: ["SelectableCollectionView"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/inseven/interact.git",  .upToNextMajor(from: "2.13.0"))
+        .package(path: "MacResources"),
+        .package(url: "https://github.com/inseven/interact.git",  .upToNextMajor(from: "2.13.0")),
+        .package(url: "https://github.com/inseven/licensable.git", .upToNextMajor(from: "0.0.1")),
+        .package(url: "https://github.com/tribalworldwidelondon/CassowarySwift.git", from: "2.0.0"),
     ],
     targets: [
         .target(
             name: "SelectableCollectionView",
             dependencies: [
+                .product(name: "Cassowary", package: "CassowarySwift"),
                 .product(name: "Interact", package: "Interact"),
+                .product(name: "Licensable", package: "Licensable"),
+                .product(name: "SelectableCollectionViewMacResources",
+                         package: "MacResources",
+                         condition: .when(platforms: [.macOS])),
             ],
             resources: [.process("Resources")]),
         .testTarget(

--- a/Sources/SelectableCollectionView/Environment/HighlightState.swift
+++ b/Sources/SelectableCollectionView/Environment/HighlightState.swift
@@ -21,12 +21,12 @@
 import SwiftUI
 
 public struct HighlightState: EnvironmentKey {
-    public static let defaultValue: NSCollectionViewItem.HighlightState = .none
+    public static let defaultValue: CollectionViewItemHighlightState = .none
 }
 
 extension EnvironmentValues {
 
-    public var highlightState: NSCollectionViewItem.HighlightState {
+    public var highlightState: CollectionViewItemHighlightState {
         get { self[HighlightState.self] }
         set { self[HighlightState.self] = newValue }
     }

--- a/Sources/SelectableCollectionView/Extensions/Licensable.swift
+++ b/Sources/SelectableCollectionView/Extensions/Licensable.swift
@@ -18,16 +18,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if os(macOS)
-
 import Foundation
 
-extension NSEdgeInsets: Equatable {
+import Licensable
 
-    public static func == (lhs: NSEdgeInsets, rhs: NSEdgeInsets) -> Bool {
-        return NSEdgeInsetsEqual(lhs, rhs)
+extension Licensable where Self == License {
+
+    public static var cassowarySwift: License {
+
+        let licenseURL = Bundle.module.url(forResource: "cassowaryswift-license", withExtension: nil)!
+
+        return License(name: "CassowarySwift",
+                       author: "Tribal Worldwide London, Alex Birkett",
+                       text: try! String(contentsOf: licenseURL))
+    }
+
+    public static var selectableCollectionView: License {
+
+        let licenseURL = Bundle.module.url(forResource: "LICENSE", withExtension: nil)!
+
+        return License(id: "https://github.com/jbmorley/selectablecollectionview",
+                       name: "SelectableCollectionView",
+                       author: "Jason Morley",
+                       text: try! String(contentsOf: licenseURL),
+                       attributes: [
+                           .url(URL(string: "https://github.com/jbmorley/selectablecollectionview")!, title: "GitHub"),
+                       ],
+                       licenses: [
+                           .licensable,
+                           .cassowarySwift,
+                       ])
     }
 
 }
 
-#endif

--- a/Sources/SelectableCollectionView/Extensions/NSDirectionalEdgeInsets.swift
+++ b/Sources/SelectableCollectionView/Extensions/NSDirectionalEdgeInsets.swift
@@ -24,6 +24,13 @@ import AppKit
 
 extension NSDirectionalEdgeInsets: Equatable {
 
+    init(_ size: CGFloat) {
+        self.init(top: size,
+                  leading: size,
+                  bottom: size,
+                  trailing: size)
+    }
+
 #warning("TODO: Floating-point comparison")
     public static func == (lhs: NSDirectionalEdgeInsets, rhs: NSDirectionalEdgeInsets) -> Bool {
         return (lhs.top == rhs.top &&

--- a/Sources/SelectableCollectionView/Extensions/NSDirectionalEdgeInsets.swift
+++ b/Sources/SelectableCollectionView/Extensions/NSDirectionalEdgeInsets.swift
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
+
 import AppKit
 
 extension NSDirectionalEdgeInsets: Equatable {
@@ -31,3 +33,5 @@ extension NSDirectionalEdgeInsets: Equatable {
     }
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Extensions/NSSize.swift
+++ b/Sources/SelectableCollectionView/Extensions/NSSize.swift
@@ -18,35 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import SwiftUI
-
-extension GridItem: Equatable, Hashable {
-
-    // TODO: THIS IS A HACK
-    public static func == (lhs: GridItem, rhs: GridItem) -> Bool {
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-
-    }
-
-}
-
-public struct GridItemLayout: Layoutable, Hashable {
-
-    let columns: [GridItem]
-    let spacing: CGFloat?
-
-    public init(columns: [GridItem], spacing: CGFloat?) {
-        self.columns = columns
-        self.spacing = spacing
-    }
-
 #if os(macOS)
-    public func makeLayout() -> NSCollectionViewLayout {
-        return GridItemCollectionViewLayout(columns: columns, spacing: spacing)
+
+import AppKit
+
+extension NSSize {
+
+    func inset(by edgeInsets: NSDirectionalEdgeInsets) -> NSSize {
+        return NSSize(width: width - (edgeInsets.leading + edgeInsets.trailing),
+                      height: height - (edgeInsets.top + edgeInsets.bottom))
     }
-#endif
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Layouts/ColumnCollectionViewLayout.swift
+++ b/Sources/SelectableCollectionView/Layouts/ColumnCollectionViewLayout.swift
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
+
 import AppKit
 
 class ColumnCollectionViewLayout: NSCollectionViewFlowLayout {
@@ -57,3 +59,5 @@ class ColumnCollectionViewLayout: NSCollectionViewFlowLayout {
     }
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Layouts/FixedItemSizeCollectionViewLayout.swift
+++ b/Sources/SelectableCollectionView/Layouts/FixedItemSizeCollectionViewLayout.swift
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
+
 import AppKit
 
 class FixedItemSizeCollectionViewLayout: NSCollectionViewCompositionalLayout {
@@ -43,3 +45,5 @@ class FixedItemSizeCollectionViewLayout: NSCollectionViewCompositionalLayout {
     }
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Layouts/FixedItemSizeLayout.swift
+++ b/Sources/SelectableCollectionView/Layouts/FixedItemSizeLayout.swift
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
+
 import AppKit
 
 public struct FixedItemSizeLayout: Layoutable {
@@ -43,3 +45,5 @@ public struct FixedItemSizeLayout: Layoutable {
     }
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Layouts/GridItemCollectionViewLayout.swift
+++ b/Sources/SelectableCollectionView/Layouts/GridItemCollectionViewLayout.swift
@@ -1,0 +1,142 @@
+// Copyright (c) 2022 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if os(macOS)
+
+import AppKit
+import SwiftUI
+
+import Cassowary
+
+class GridItemCollectionViewLayout: NSCollectionViewCompositionalLayout {
+
+    init(columns: [GridItem]) {
+        super.init(sectionProvider: { (sectionIndex: Int,
+                                       layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection in
+
+            // SwiftUI's `GridItem` layout model is a bit of a hybrid, some of which we need a constraints solver for,
+            // and some of which we can easily code up manually. The documentation defines the three cases as follows:
+            //
+            // - .adaptive(minimum:maximum:)
+            //
+            //   Multiple items in the space of a single flexible item.
+            //
+            //   This size case places one or more items into the space assigned to a single flexible item, using the
+            //   provided bounds and spacing to decide exactly how many items fit. This approach prefers to insert as
+            //   many items of the minimum size as possible but lets them increase to the maximum size.
+            //
+            // - .fixed(_:)
+            //
+            //   A single item with the specified fixed size.
+            //
+            // - .flexible(minimum:maximum:)
+            //
+            //   A single flexible item.
+            //
+            //   The size of this item is the size of the grid with spacing and inflexible items removed, divided by the
+            //   number of flexible items, clamped to the provided bounds.
+            //
+            // This, I think, means that treat `.adaptive` as a container, and only once we've worked out the dimensions
+            // of that container, do we then calculate the number of columns required in that container.
+
+            struct ColumnDetails {
+                let width: Variable
+                let definition: GridItem.Size
+
+                var layoutItmes: [NSCollectionLayoutItem] {
+                    switch definition {
+                    case .fixed, .flexible:
+                        let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(width.value),
+                                                              heightDimension: .estimated(10))
+                        return [NSCollectionLayoutItem(layoutSize: itemSize)]
+                    case .adaptive(let minimum, let maximum):
+                        // TODO: What happens if it's not a perfect fit?
+                        print(width.value)
+                        let width = width.value
+                        let columns = max(1.0, floor(width / minimum))
+                        let itemWidth = width / columns
+                        let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(itemWidth),
+                                                              heightDimension: .estimated(10))
+                        var items: [NSCollectionLayoutItem] = []
+                        for i in 0..<Int(columns) {
+                            items.append(NSCollectionLayoutItem(layoutSize: itemSize))
+                        }
+                        return items
+                    }
+                }
+            }
+
+            let contentSize = layoutEnvironment.container.effectiveContentSize
+            var remainingWidth = Expression(constant: contentSize.width)
+
+            let solver = Solver()
+            var dimensions: [ColumnDetails] = []
+            for (i, column) in columns.enumerated() {
+
+                let dimension = Variable("column\(i)")
+                let details = ColumnDetails(width: dimension, definition: column.size)
+                dimensions.append(details)
+
+                remainingWidth = remainingWidth - dimension
+
+                switch column.size {
+                case .fixed(let width):
+                    try? solver.addConstraint(dimension == width)
+                case .flexible(minimum: let minimum, maximum: let maximum):
+                    try? solver.addConstraint(dimension >= minimum)
+                    try? solver.addConstraint(dimension <= maximum)
+                case .adaptive(minimum: let minimum, maximum: let maximum):
+                    try? solver.addConstraint(dimension >= minimum)
+                    try? solver.addConstraint(dimension <= maximum)
+                @unknown default:
+                    fatalError("Unsupported column size \(column).")
+                }
+            }
+
+            // TODO: Spacing.
+
+            try? solver.addConstraint(remainingWidth == 0)
+            solver.updateVariables()
+
+            // TODO: Double check to see what .fixed(10) does on iOS??
+            let items = dimensions
+                .map { dimension in
+                    return dimension.layoutItmes  // TODO: Make layout items?
+                }
+                .reduce([], +)
+
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(10))
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: items)
+            group.interItemSpacing = .fixed(0.0)
+
+            let section = NSCollectionLayoutSection(group: group)
+            section.interGroupSpacing = 0.0
+
+            return section
+        })
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+#endif

--- a/Sources/SelectableCollectionView/Layouts/GridItemLayout.swift
+++ b/Sources/SelectableCollectionView/Layouts/GridItemLayout.swift
@@ -18,31 +18,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if os(macOS)
-
 import SwiftUI
 
-public struct ColumnLayout: Layoutable {
+extension GridItem: Equatable, Hashable {
 
-    let spacing: CGFloat
-    let columns: Int
-    let edgeInsets: NSEdgeInsets
-
-    public init(spacing: CGFloat, columns: Int, edgeInsets: NSEdgeInsets) {
-        self.spacing = spacing
-        self.columns = columns
-        self.edgeInsets = edgeInsets
+    // TODO: THIS IS A HACK
+    public static func == (lhs: GridItem, rhs: GridItem) -> Bool {
+        return true
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(spacing)
-        hasher.combine(columns)
-    }
 
-    public func makeLayout() -> NSCollectionViewLayout {
-        return ColumnCollectionViewLayout(spacing: spacing, columns: columns, edgeInsets: edgeInsets)
     }
 
 }
 
+public struct GridItemLayout: Layoutable, Hashable {
+
+    let columns: [GridItem]
+
+    public init(columns: [GridItem]) {
+        self.columns = columns
+    }
+
+#if os(macOS)
+    public func makeLayout() -> NSCollectionViewLayout {
+        return GridItemCollectionViewLayout(columns: columns)
+    }
 #endif
+
+}

--- a/Sources/SelectableCollectionView/Layouts/Layoutable.swift
+++ b/Sources/SelectableCollectionView/Layouts/Layoutable.swift
@@ -18,11 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
 import AppKit
+#endif
 
 #warning("TODO: This needs to be equatable")
 public protocol Layoutable: Hashable {
 
+#if os(macOS)
     func makeLayout() -> NSCollectionViewLayout
+#endif
 
 }

--- a/Sources/SelectableCollectionView/Model/CollectionViewItemHighlightState.swift
+++ b/Sources/SelectableCollectionView/Model/CollectionViewItemHighlightState.swift
@@ -18,31 +18,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if os(macOS)
-
 import SwiftUI
 
-public struct ColumnLayout: Layoutable {
-
-    let spacing: CGFloat
-    let columns: Int
-    let edgeInsets: NSEdgeInsets
-
-    public init(spacing: CGFloat, columns: Int, edgeInsets: NSEdgeInsets) {
-        self.spacing = spacing
-        self.columns = columns
-        self.edgeInsets = edgeInsets
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(spacing)
-        hasher.combine(columns)
-    }
-
-    public func makeLayout() -> NSCollectionViewLayout {
-        return ColumnCollectionViewLayout(spacing: spacing, columns: columns, edgeInsets: edgeInsets)
-    }
-
+public enum CollectionViewItemHighlightState {
+    case none
+    case forSelection
+    case forDeselection
+    case asDropTarget
 }
 
+extension CollectionViewItemHighlightState {
+
+#if os(macOS)
+    init(_ highlightState: NSCollectionViewItem.HighlightState) {
+        switch highlightState {
+        case .none:
+            self = .none
+        case .forSelection:
+            self = .forSelection
+        case .forDeselection:
+            self = .forDeselection
+        case .asDropTarget:
+            self = .asDropTarget
+        @unknown default:
+            print("Unknown highlight state \(highlightState)")
+            self = .none
+        }
+    }
 #endif
+
+}

--- a/Sources/SelectableCollectionView/Resources/LICENSE
+++ b/Sources/SelectableCollectionView/Resources/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Jason Morley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/SelectableCollectionView/Resources/cassowaryswift-license
+++ b/Sources/SelectableCollectionView/Resources/cassowaryswift-license
@@ -1,0 +1,28 @@
+Copyright (c) 2017, Tribal Worldwide London
+Copyright (c) 2015, Alex Birkett
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of kiwi-java nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
+++ b/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
@@ -18,8 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
+
 import Carbon
 import SwiftUI
+
+import SelectableCollectionViewMacResources
 
 import Interact
 
@@ -58,10 +62,10 @@ class CustomScrollView: NSScrollView {
         }
         super.keyUp(with: event)
     }
-    
+
 }
 
-public class CollectionViewContainer<Element: Hashable, Content: View>: NSView, NSCollectionViewDelegate, CustomCollectionViewMenuDelegate {
+public class CollectionViewContainer<Element: Hashable, Content: View>: NSView, NSCollectionViewDelegate, CustomCollectionViewMenuDelegate, NSCollectionViewDelegateFlowLayout {
 
     weak var delegate: CollectionViewContainerDelegate?
 
@@ -116,7 +120,7 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView, 
         collectionView.delegate = self
         collectionView.menuDelegate = self
 
-        let itemNib = NSNib(nibNamed: "ShortcutItemView", bundle: .module)
+        let itemNib = NSNib(nibNamed: "ShortcutItemView", bundle: Resources.bundle)
         collectionView.register(itemNib, forItemWithIdentifier: ShortcutItemView.identifier)
         collectionView.register(ShortcutItemView.self, forItemWithIdentifier: ShortcutItemView.identifier)
 
@@ -232,3 +236,5 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView, 
     }
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Views/CustomCollectionView.swift
+++ b/Sources/SelectableCollectionView/Views/CustomCollectionView.swift
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
+
 import AppKit
 import Carbon
 
@@ -82,3 +84,5 @@ class CustomCollectionView: NSCollectionView {
     }
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Views/SelectableCollectionView.swift
+++ b/Sources/SelectableCollectionView/Views/SelectableCollectionView.swift
@@ -102,6 +102,7 @@ public struct SelectableCollectionView<Data: RandomAccessCollection,
     public init(_ items: Data,
                 selection: Binding<Set<Data.Element.ID>>,
                 columns: [GridItem],
+                spacing: CGFloat? = nil,
                 @ViewBuilder itemContent: @escaping (Data.Element) -> Content,
                 @MenuItemBuilder contextMenu: @escaping (Set<Data.Element.ID>) -> [MenuItem],
                 primaryAction: @escaping (Set<Data.Element.ID>) -> Void,
@@ -109,7 +110,7 @@ public struct SelectableCollectionView<Data: RandomAccessCollection,
                 keyUp: @escaping (NSEvent) -> Bool = { _ in return false }) {
         self.init(items,
                   selection: selection,
-                  layout: GridItemLayout(columns: columns),
+                  layout: GridItemLayout(columns: columns, spacing: spacing),
                   itemContent: itemContent,
                   contextMenu: contextMenu,
                   primaryAction: primaryAction)
@@ -172,6 +173,7 @@ public struct SelectableCollectionView<Data: RandomAccessCollection,
     let items: Data
     let selection: Binding<Set<Data.Element.ID>>
     let columns: [GridItem]
+    let spacing: CGFloat?
     let itemContent: (Data.Element) -> Content
     let contextMenu: (Set<Data.Element.ID>) -> [MenuItem]
     let primaryAction: (Set<Data.Element.ID>) -> ()
@@ -181,6 +183,7 @@ public struct SelectableCollectionView<Data: RandomAccessCollection,
     public init(_ items: Data,
                 selection: Binding<Set<Data.Element.ID>>,
                 columns: [GridItem],
+                spacing: CGFloat? = nil,
                 @ViewBuilder itemContent: @escaping (Data.Element) -> Content,
                 @MenuItemBuilder contextMenu: @escaping (Set<Data.Element.ID>) -> [MenuItem],
                 primaryAction: @escaping (Set<Data.Element.ID>) -> Void/*,
@@ -189,6 +192,7 @@ public struct SelectableCollectionView<Data: RandomAccessCollection,
         self.items = items
         self.selection = selection
         self.columns = columns
+        self.spacing = spacing
         self.itemContent = itemContent
         self.contextMenu = contextMenu
         self.primaryAction = primaryAction
@@ -198,7 +202,7 @@ public struct SelectableCollectionView<Data: RandomAccessCollection,
 
     public var body: some View {
         ScrollView {
-            LazyVGrid(columns: columns) {
+            LazyVGrid(columns: columns, spacing: spacing) {
                 ForEach(items) { item in
                     itemContent(item)
                         .contextMenu {

--- a/Sources/SelectableCollectionView/Views/ShortcutItemView.swift
+++ b/Sources/SelectableCollectionView/Views/ShortcutItemView.swift
@@ -18,7 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if os(macOS)
+
 import SwiftUI
+
+import SelectableCollectionViewMacResources
 
 #warning("TODO: Can we type this internally?")
 class ShortcutItemView: NSCollectionViewItem {
@@ -49,7 +53,7 @@ class ShortcutItemView: NSCollectionViewItem {
     }
 
     override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nil, bundle: .module)
+        super.init(nibName: nil, bundle: Resources.bundle)
     }
 
     required init?(coder: NSCoder) {
@@ -59,7 +63,7 @@ class ShortcutItemView: NSCollectionViewItem {
     private func host(_ content: AnyView) {
         let modifiedContent = AnyView(content
             .environment(\.isSelected, isSelected)
-            .environment(\.highlightState, highlightState))
+            .environment(\.highlightState, .init(highlightState)))
         if let hostingView = hostingView {
             hostingView.rootView = modifiedContent
         } else {
@@ -95,3 +99,4 @@ class ShortcutItemView: NSCollectionViewItem {
 
 }
 
+#endif


### PR DESCRIPTION
This change introduces support for iOS 16 and above. It does not currently support selection on iOS, but instead uses `LazyVGrid` under the hood to allow the same source to compile across both iOS and macOS. In order to do this, it introduces support for SwiftUI's column-based layout definitions on iOS and macOS.