### PR TITLE
fix: Support wrapping selection on keyboard navigation

### DIFF
--- a/Sources/SelectableCollectionView/Extensions/NSCollectionView.swift
+++ b/Sources/SelectableCollectionView/Extensions/NSCollectionView.swift
@@ -1,0 +1,184 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if os(macOS)
+
+import AppKit
+
+extension NSCollectionView {
+
+    func isSelected(_ indexPath: IndexPath?) -> Bool {
+        guard let indexPath else {
+            return false
+        }
+        return selectionIndexPaths.contains(indexPath)
+    }
+
+    func firstIndexPath() -> IndexPath? {
+        return self.indexPath(after: IndexPath(item: -1, section: 0))
+    }
+
+    func lastIndexPath() -> IndexPath? {
+        return self.indexPath(before: IndexPath(item: 0, section: numberOfSections))
+    }
+
+    fileprivate func indexPath(before indexPath: IndexPath) -> IndexPath? {
+
+        // Try decrementing the item...
+        if indexPath.item - 1 >= 0 {
+            return IndexPath(item: indexPath.item - 1, section: indexPath.section)
+        }
+
+        // Try decrementing the section...
+        var nextSection = indexPath.section
+        while true {
+            nextSection -= 1
+            guard nextSection >= 0 else {
+                return nil
+            }
+            let numberOfItems = numberOfItems(inSection: nextSection)
+            if numberOfItems > 0 {
+                return IndexPath(item: numberOfItems - 1, section: nextSection)
+            }
+        }
+
+    }
+
+    fileprivate func indexPath(after indexPath: IndexPath) -> IndexPath? {
+
+        // Try incrementing the item...
+        if indexPath.item + 1 < numberOfItems(inSection: indexPath.section) {
+            return IndexPath(item: indexPath.item + 1, section: indexPath.section)
+        }
+
+        // Try incrementing the section...
+        var nextSection = indexPath.section
+        while true {
+            nextSection += 1
+            guard nextSection < numberOfSections else {
+                return nil
+            }
+            if numberOfItems(inSection: nextSection) > 0 {
+                return IndexPath(item: 0, section: nextSection)
+            }
+        }
+
+    }
+
+    func indexPathSequence(following indexPath: IndexPath, direction: SequenceDirection) -> IndexPathSequence {
+        return IndexPathSequence(collectionView: self, indexPath: indexPath, direction: direction)
+    }
+
+    func indexPath(following indexPath: IndexPath, direction: SequenceDirection, distance: Int = 1) -> IndexPath? {
+        var indexPath: IndexPath? = indexPath
+        for _ in 0..<distance {
+            guard let testIndexPath = indexPath else {
+                return nil
+            }
+            switch direction {
+            case .forwards:
+                indexPath = self.indexPath(after: testIndexPath)
+            case .backwards:
+                indexPath = self.indexPath(before: testIndexPath)
+            }
+        }
+        return indexPath
+    }
+
+    func closestIndexPath(toIndexPath indexPath: IndexPath, direction: NavigationDirection) -> CollectionViewNavigationResult? {
+
+        guard let layout = collectionViewLayout else {
+            return nil
+        }
+
+        let threshold = 20.0
+        let attributesForCurrentItem = layout.layoutAttributesForItem(at: indexPath)
+        let currentItemFrame = attributesForCurrentItem?.frame ?? .zero
+        let targetPoint: CGPoint
+        let indexPaths: IndexPathSequence
+        switch direction {
+        case .up:
+            targetPoint = CGPoint(x: currentItemFrame.midX, y: currentItemFrame.minY - threshold)
+            indexPaths = self.indexPathSequence(following: indexPath, direction: .backwards)
+        case .down:
+            targetPoint = CGPoint(x: currentItemFrame.midX, y: currentItemFrame.maxY + threshold)
+            indexPaths = self.indexPathSequence(following: indexPath, direction: .forwards)
+        case .left:
+            targetPoint = CGPoint(x: currentItemFrame.minX - threshold, y: currentItemFrame.midY)
+            indexPaths = self.indexPathSequence(following: indexPath, direction: .backwards)
+        case .right:
+            targetPoint = CGPoint(x: currentItemFrame.maxX + threshold, y: currentItemFrame.midY)
+            indexPaths = self.indexPathSequence(following: indexPath, direction: .forwards)
+        }
+
+        // This takes a really simple approach that either walks forwards or backwards through the cells to find the
+        // next cell. It will fail hard on sparsely packed layouts or layouts which place elements randomly but feels
+        // like a reasonable limitation given the current planned use-cases.
+        //
+        // A more flexible implementation might compute the vector from our current item to the test item and select one
+        // with the lowest magnitude closest to the requested direction. It might also be possible to use this approach
+        // to do wrapping more 'correctly'.
+        //
+        // Seeking should probably also be limited to a maximum nubmer of test items to avoid walking thousands of items
+        // if no obvious match is found.
+
+        var intermediateIndexPaths: [IndexPath] = []
+        for indexPath in indexPaths {
+            if let attributes = layout.layoutAttributesForItem(at: indexPath),
+               attributes.frame.contains(targetPoint) {
+                return CollectionViewNavigationResult(nextIndexPath: indexPath, intermediateIndexPaths: intermediateIndexPaths)
+            }
+            intermediateIndexPaths.append(indexPath)
+        }
+        return nil
+    }
+
+    func nextIndex(_ direction: NavigationDirection, indexPath: IndexPath?) -> CollectionViewNavigationResult? {
+
+        // This implementation makes some assumptions that will work with packed grid-like layouts but are unlikely to
+        // work well with sparsely packed layouts or irregular layouts. Specifically:
+        //
+        // - Left/Right directions are always assumed to selection the previous or next index paths by item and section.
+        //
+        // - Up/Down will seek through the index paths in order and return the index path of the first item which
+        //   contains a point immediately above or below the starting index path.
+
+        guard let indexPath else {
+            switch direction.sequenceDirection {
+            case .forwards:
+                return CollectionViewNavigationResult(nextIndexPath: firstIndexPath())
+            case .backwards:
+                return CollectionViewNavigationResult(nextIndexPath: lastIndexPath())
+            }
+        }
+
+        switch direction {
+        case .up, .down:
+            return closestIndexPath(toIndexPath: indexPath, direction: direction)
+        case .left:
+            return CollectionViewNavigationResult(nextIndexPath: self.indexPath(following: indexPath, direction: .backwards))
+        case .right:
+            return CollectionViewNavigationResult(nextIndexPath: self.indexPath(following: indexPath, direction: .forwards))
+        }
+    }
+
+}
+
+#endif

--- a/Sources/SelectableCollectionView/Utilities/CollectionViewNavigationResult.swift
+++ b/Sources/SelectableCollectionView/Utilities/CollectionViewNavigationResult.swift
@@ -18,17 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import SwiftUI
+import Foundation
 
-public struct SelectionColor: EnvironmentKey {
-    public static let defaultValue: Color = .accentColor
-}
+struct CollectionViewNavigationResult {
+    let nextIndexPath: IndexPath
+    let intermediateIndexPaths: [IndexPath]
 
-extension EnvironmentValues {
-
-    public var selectionColor: Color {
-        get { self[SelectionColor.self] }
-        set { self[SelectionColor.self] = newValue }
+    init?(nextIndexPath: IndexPath?, intermediateIndexPaths: [IndexPath] = []) {
+        guard let nextIndexPath else {
+            return nil
+        }
+        self.nextIndexPath = nextIndexPath
+        self.intermediateIndexPaths = intermediateIndexPaths
     }
-
 }

--- a/Sources/SelectableCollectionView/Utilities/IndexPathSequence.swift
+++ b/Sources/SelectableCollectionView/Utilities/IndexPathSequence.swift
@@ -1,0 +1,74 @@
+// Copyright (c) 2022-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if os(macOS)
+
+import AppKit
+
+struct IndexPathSequence: Sequence {
+
+    struct Iterator: IteratorProtocol {
+
+        let collectionView: NSCollectionView
+        var indexPath: IndexPath
+        let direction: SequenceDirection
+
+        init(collectionView: NSCollectionView, indexPath: IndexPath, direction: SequenceDirection) {
+            self.collectionView = collectionView
+            self.indexPath = indexPath
+            self.direction = direction
+        }
+
+        mutating func next() -> IndexPath? {
+            switch direction {
+            case .forwards:
+                guard let nextIndexPath = collectionView.indexPath(following: indexPath, direction: direction) else {
+                    return nil
+                }
+                indexPath = nextIndexPath
+                return indexPath
+            case .backwards:
+                guard let nextIndexPath = collectionView.indexPath(following: indexPath, direction: direction) else {
+                    return nil
+                }
+                indexPath = nextIndexPath
+                return indexPath
+            }
+        }
+
+    }
+
+    let collectionView: NSCollectionView
+    let indexPath: IndexPath
+    let direction: SequenceDirection
+
+    init(collectionView: NSCollectionView, indexPath: IndexPath, direction: SequenceDirection = .forwards) {
+        self.collectionView = collectionView
+        self.indexPath = indexPath
+        self.direction = direction
+    }
+
+    func makeIterator() -> Iterator {
+        return Iterator(collectionView: collectionView, indexPath: indexPath, direction: direction)
+    }
+
+}
+
+#endif

--- a/Sources/SelectableCollectionView/Utilities/NavigationDirection.swift
+++ b/Sources/SelectableCollectionView/Utilities/NavigationDirection.swift
@@ -18,17 +18,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import SwiftUI
+#if os(macOS)
 
-public struct SelectionColor: EnvironmentKey {
-    public static let defaultValue: Color = .accentColor
-}
+import AppKit
+import Carbon
 
-extension EnvironmentValues {
+enum NavigationDirection {
+    case up
+    case down
+    case left
+    case right
 
-    public var selectionColor: Color {
-        get { self[SelectionColor.self] }
-        set { self[SelectionColor.self] = newValue }
+    init?(_ keyCode: UInt16) {
+        switch Int(keyCode) {
+        case kVK_LeftArrow:
+            self = .left
+        case kVK_RightArrow:
+            self = .right
+        case kVK_UpArrow:
+            self = .up
+        case kVK_DownArrow:
+            self = .down
+        default:
+            return nil
+        }
     }
 
 }
+
+#endif

--- a/Sources/SelectableCollectionView/Utilities/SequenceDirection.swift
+++ b/Sources/SelectableCollectionView/Utilities/SequenceDirection.swift
@@ -18,17 +18,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import SwiftUI
+import Foundation
 
-public struct SelectionColor: EnvironmentKey {
-    public static let defaultValue: Color = .accentColor
+enum SequenceDirection {
+    case forwards
+    case backwards
+
+    static prefix func !(direction: SequenceDirection) -> SequenceDirection {
+        switch direction {
+        case .forwards:
+            return .backwards
+        case .backwards:
+            return .forwards
+        }
+
+    }
 }
 
-extension EnvironmentValues {
+extension NavigationDirection {
 
-    public var selectionColor: Color {
-        get { self[SelectionColor.self] }
-        set { self[SelectionColor.self] = newValue }
+    var sequenceDirection: SequenceDirection {
+        switch self {
+        case .up, .left:
+            return .backwards
+        case .down, .right:
+            return .forwards
+        }
     }
 
 }

--- a/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
+++ b/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
@@ -67,7 +67,7 @@ class CustomScrollView: NSScrollView {
 
 public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
                                                                         NSCollectionViewDelegate,
-                                                                        CustomCollectionViewMenuDelegate,
+                                                                        InteractiveCollectionViewDelegate,
                                                                         NSCollectionViewDelegateFlowLayout {
 
     weak var delegate: CollectionViewContainerDelegate?
@@ -81,7 +81,7 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
     typealias Cell = ShortcutItemView
 
     private let scrollView: CustomScrollView
-    private let collectionView: CustomCollectionView
+    private let collectionView: InteractiveCollectionView
     private var dataSource: DataSource? = nil
 
     var provider: ((Element) -> Content?)? = nil
@@ -94,7 +94,7 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = false
 
-        collectionView = CustomCollectionView()
+        collectionView = InteractiveCollectionView()
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.collectionViewLayout = layout
         super.init(frame: .zero)
@@ -121,7 +121,7 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
         scrollView.documentView = collectionView
         collectionView.dataSource = dataSource
         collectionView.delegate = self
-        collectionView.menuDelegate = self
+        collectionView.interactionDelegate = self
 
         let itemNib = NSNib(nibNamed: "ShortcutItemView", bundle: Resources.bundle)
         collectionView.register(itemNib, forItemWithIdentifier: ShortcutItemView.identifier)
@@ -172,7 +172,7 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
         action()
     }
 
-    func customCollectionView(_ customCollectionView: CustomCollectionView,
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView,
                               contextMenuForSelection _: IndexSet) -> NSMenu? {
 
         guard let menuItems = delegate?.collectionViewContainer(self, menuItemsForElements: selectedElements),
@@ -204,15 +204,15 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
         delegate?.collectionViewContainer(self, didUpdateSelection: selectedElements)
     }
 
-    func customCollectionView(_ customCollectionView: CustomCollectionView, didUpdateSelection selection: Set<IndexPath>) {
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateSelection selection: Set<IndexPath>) {
         updateSelection()
     }
 
-    func customCollectionView(_ customCollectionView: CustomCollectionView, didDoubleClickSelection selection: Set<IndexPath>) {
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didDoubleClickSelection selection: Set<IndexPath>) {
         delegate?.collectionViewContainer(self, didDoubleClickSelection: selectedElements)
     }
 
-    func customCollectionView(_ customCollectionView: CustomCollectionView, didUpdateFocus isFirstResponder: Bool) {
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateFocus isFirstResponder: Bool) {
         updateSelection()
     }
 

--- a/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
+++ b/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
@@ -67,7 +67,7 @@ class CustomScrollView: NSScrollView {
 
 public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
                                                                         NSCollectionViewDelegate,
-                                                                        InteractiveCollectionViewDelegate,
+                                                                        CollectionViewInteractionDelegate,
                                                                         NSCollectionViewDelegateFlowLayout {
 
     weak var delegate: CollectionViewContainerDelegate?
@@ -172,8 +172,8 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
         action()
     }
 
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView,
-                              contextMenuForSelection _: IndexSet) -> NSMenu? {
+    func collectionView(_ collectionView : InteractiveCollectionView,
+                        contextMenuForSelection _: Set<IndexPath>) -> NSMenu? {
 
         guard let menuItems = delegate?.collectionViewContainer(self, menuItemsForElements: selectedElements),
               !menuItems.isEmpty
@@ -204,15 +204,15 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
         delegate?.collectionViewContainer(self, didUpdateSelection: selectedElements)
     }
 
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateSelection selection: Set<IndexPath>) {
+    func collectionView(_ collectionView: InteractiveCollectionView, didUpdateSelection selection: Set<IndexPath>) {
         updateSelection()
     }
 
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didDoubleClickSelection selection: Set<IndexPath>) {
+    func collectionView(_ collectionView: InteractiveCollectionView, didDoubleClickSelection selection: Set<IndexPath>) {
         delegate?.collectionViewContainer(self, didDoubleClickSelection: selectedElements)
     }
 
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateFocus isFirstResponder: Bool) {
+    func collectionView(_ collectionView: InteractiveCollectionView, didUpdateFocus isFirstResponder: Bool) {
         updateSelection()
     }
 

--- a/Sources/SelectableCollectionView/Views/CustomCollectionView.swift
+++ b/Sources/SelectableCollectionView/Views/CustomCollectionView.swift
@@ -32,9 +32,33 @@ protocol CustomCollectionViewMenuDelegate: NSObject {
 
 }
 
+// TODO: Rename to InteractiveCollectionView
 class CustomCollectionView: NSCollectionView {
 
+    // TODO: Rename
     weak var menuDelegate: CustomCollectionViewMenuDelegate?
+
+    var cursor: IndexPath?
+
+    func fixupSelection(direction: NavigationDirection) {
+
+        // Sometimes the selection can change outside of our control, so we implement the following recovery
+        // mechanism. This seems to match the implementation in Photos.app.
+        //
+        // Specifically, if the current cursor is outside the selection, we place the cursor at the first or last
+        // selected item depending on the requested navigation direction--up/left will use the first selected item, and
+        // down/right will find the last selected item.
+
+        if cursor == nil {
+            switch direction.sequenceDirection {
+            case .forwards:
+                self.cursor = selectionIndexPaths.max()
+            case .backwards:
+                self.cursor = selectionIndexPaths.min()
+            }
+            return
+        }
+    }
 
     override func menu(for event: NSEvent) -> NSMenu? {
 
@@ -59,12 +83,105 @@ class CustomCollectionView: NSCollectionView {
     }
 
     override func mouseDown(with event: NSEvent) {
+
+        window?.makeFirstResponder(self)
+
+        let position = self.convert(event.locationInWindow, from: nil)
+        if let indexPath = self.indexPathForItem(at: position) {
+
+            if event.modifierFlags.contains(.shift) {
+
+                // Looking at the implementation of Photos (which we're trying to match), shift click always expands the
+                // selection and resets the cursor to the new position if the new position represents a modification.
+
+                if let cursor {
+
+                    // Shift clicking on a currently selected item does nothing.
+                    guard !selectionIndexPaths.contains(indexPath) else {
+                        return
+                    }
+
+                    if indexPath > cursor {
+                        var indexPaths = Set<IndexPath>()
+                        for i in self.indexPathSequence(following: cursor, direction: .forwards) {
+                            guard i <= indexPath else {
+                                break
+                            }
+                            indexPaths.insert(i)
+                        }
+                        selectItems(at: indexPaths, scrollPosition: [])
+                        delegate?.collectionView?(self, didSelectItemsAt: indexPaths)
+
+                        // Reset the selection bounds, placing the cursor at the new highlight.
+                        self.cursor = indexPath
+
+                    } else {
+                        var indexPaths = Set<IndexPath>()
+                        for i in self.indexPathSequence(following: cursor, direction: .backwards) {
+                            guard i >= indexPath else {
+                                break
+                            }
+                            indexPaths.insert(i)
+                        }
+                        selectItems(at: indexPaths, scrollPosition: [])
+                        delegate?.collectionView?(self, didSelectItemsAt: indexPaths)
+
+                        // Reset the selection bounds, placing the cursor at the new highlight.
+                        self.cursor = indexPath
+                    }
+
+                }
+
+            } else if event.modifierFlags.contains(.command) {
+
+                // This behaves like shift click if the new item is contiguous with the current selection. If not, it
+                // breaks the current selection and resets it to largest bounds that contain the new selection.
+
+                let selectionIndexPaths = selectionIndexPaths
+                if selectionIndexPaths.contains(indexPath) {
+                    deselectItems(at: [indexPath])
+                    delegate?.collectionView?(self, didDeselectItemsAt: [indexPath])
+
+                    // Here again, we copy Photos which treats deselecting the cursor as a complete selection reset.
+                    if cursor == indexPath {
+                        cursor = nil
+                        return
+                    }
+
+                } else {
+                    selectItems(at: [indexPath], scrollPosition: [])
+                    delegate?.collectionView?(self, didSelectItemsAt: [indexPath])
+                    cursor = indexPath
+                }
+
+            } else {
+
+                let selectionIndexPaths = selectionIndexPaths
+                deselectItems(at: selectionIndexPaths)
+                delegate?.collectionView?(self, didDeselectItemsAt: selectionIndexPaths)
+                selectItems(at: [indexPath], scrollPosition: [])
+                delegate?.collectionView?(self, didSelectItemsAt: [indexPath])
+                cursor = indexPath
+
+            }
+
+            return
+        }
+
+        // The user is beginning a mouse-driven selection so we clear the current tracked selection; it will get fixed
+        // up on subsequent keyboard events.
+        self.cursor = nil
+
         super.mouseDown(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
 
         // Handle double-click.
-        if event.clickCount > 1,
-           !selectionIndexPaths.isEmpty {
+        if event.clickCount > 1, !selectionIndexPaths.isEmpty {
             menuDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
+            return
         }
     }
 
@@ -79,10 +196,80 @@ class CustomCollectionView: NSCollectionView {
     }
 
     override func keyDown(with event: NSEvent) {
+
+        // Propage space for 
         if event.keyCode == kVK_Space {
             nextResponder?.keyDown(with: event)
             return
         }
+
+        // Open the item.
+        if event.modifierFlags.contains(.command),
+           event.keyCode == kVK_DownArrow {
+            if !selectionIndexPaths.isEmpty {
+                menuDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
+            }
+            return
+        }
+
+        // Handle custom selection wrapping behavior.
+        if let direction = NavigationDirection(event.keyCode) {
+
+            // We perform some fixup to ensure handle non-contiguous cursor-based selection which can lead to our
+            // selection getting out of sync.
+            fixupSelection(direction: direction)
+
+            let modifierFlags = event.modifierFlags.intersection([.command, .shift])
+
+            if let navigationResult = nextIndex(direction, indexPath: cursor) {
+                if modifierFlags == .shift {
+
+                    var selections: Set<IndexPath> = []
+                    var deselections: Set<IndexPath> = []
+
+                    // Walk towards the next item.
+                    for indexPath in navigationResult.intermediateIndexPaths + [navigationResult.nextIndexPath] {
+                        let previousIndexPath = self.indexPath(following: indexPath,
+                                                               direction: !direction.sequenceDirection,
+                                                               distance: 2)
+                        if !isSelected(previousIndexPath) && isSelected(indexPath) {
+                            // Contraction.
+                            if let operationIndex = self.indexPath(following: indexPath,
+                                                                   direction: !direction.sequenceDirection,
+                                                                   distance: 1) {
+                                deselections.insert(operationIndex)
+                                selectionIndexPaths.remove(operationIndex)
+                            }
+                        } else {
+                            // Expansion.
+                            selections.insert(indexPath)
+                            selectionIndexPaths.insert(indexPath)
+                        }
+                    }
+
+                    deselectItems(at: deselections)
+                    delegate?.collectionView?(self, didDeselectItemsAt: deselections)
+                    selectItems(at: selections, scrollPosition: .nearestHorizontalEdge)
+                    delegate?.collectionView?(self, didSelectItemsAt: selections)
+                    scrollToItems(at: [navigationResult.nextIndexPath], scrollPosition: .nearestHorizontalEdge)
+                    self.cursor = navigationResult.nextIndexPath
+
+                } else if modifierFlags.isEmpty {
+
+                    // Without shift held down the selection is always reset.
+                    deselectItems(at: selectionIndexPaths)
+                    delegate?.collectionView?(self, didDeselectItemsAt: selectionIndexPaths)
+                    selectItems(at: [navigationResult.nextIndexPath], scrollPosition: .nearestHorizontalEdge)
+                    delegate?.collectionView?(self, didSelectItemsAt: [navigationResult.nextIndexPath])
+                    scrollToItems(at: [navigationResult.nextIndexPath], scrollPosition: .nearestHorizontalEdge)
+                    cursor = navigationResult.nextIndexPath
+
+                }
+
+            }
+            return
+        }
+
         super.keyDown(with: event)
     }
 

--- a/Sources/SelectableCollectionView/Views/InteractiveCollectionView.swift
+++ b/Sources/SelectableCollectionView/Views/InteractiveCollectionView.swift
@@ -23,18 +23,18 @@
 import AppKit
 import Carbon
 
-protocol InteractiveCollectionViewDelegate: NSObject {
+protocol CollectionViewInteractionDelegate: NSObject {
 
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView, contextMenuForSelection selection: IndexSet) -> NSMenu?
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateSelection selection: Set<IndexPath>)
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didDoubleClickSelection selection: Set<IndexPath>)
-    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateFocus isFirstResponder: Bool)
+    func collectionView(_ collectionView: InteractiveCollectionView, contextMenuForSelection selection: Set<IndexPath>) -> NSMenu?
+    func collectionView(_ collectionView: InteractiveCollectionView, didUpdateSelection selection: Set<IndexPath>)
+    func collectionView(_ collectionView: InteractiveCollectionView, didDoubleClickSelection selection: Set<IndexPath>)
+    func collectionView(_ collectionView: InteractiveCollectionView, didUpdateFocus isFirstResponder: Bool)
 
 }
 
 class InteractiveCollectionView: NSCollectionView {
 
-    weak var interactionDelegate: InteractiveCollectionViewDelegate?
+    weak var interactionDelegate: CollectionViewInteractionDelegate?
 
     var cursor: IndexPath?
 
@@ -69,11 +69,10 @@ class InteractiveCollectionView: NSCollectionView {
         } else {
             selectionIndexPaths = []
         }
-        interactionDelegate?.customCollectionView(self, didUpdateSelection: selectionIndexPaths)
+        interactionDelegate?.collectionView(self, didUpdateSelection: selectionIndexPaths)
 
         // Get the menu for the current selection.
-#warning("TODO: Update to selectionIndexPaths")
-        if let menu = interactionDelegate?.customCollectionView(self, contextMenuForSelection: selectionIndexes) {
+        if let menu = interactionDelegate?.collectionView(self, contextMenuForSelection: selectionIndexPaths) {
             return menu
         }
 
@@ -178,18 +177,18 @@ class InteractiveCollectionView: NSCollectionView {
 
         // Handle double-click.
         if event.clickCount > 1, !selectionIndexPaths.isEmpty {
-            interactionDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
+            interactionDelegate?.collectionView(self, didDoubleClickSelection: selectionIndexPaths)
             return
         }
     }
 
     override func becomeFirstResponder() -> Bool {
-        interactionDelegate?.customCollectionView(self, didUpdateFocus: true)
+        interactionDelegate?.collectionView(self, didUpdateFocus: true)
         return super.becomeFirstResponder()
     }
 
     override func resignFirstResponder() -> Bool {
-        interactionDelegate?.customCollectionView(self, didUpdateFocus: false)
+        interactionDelegate?.collectionView(self, didUpdateFocus: false)
         return super.resignFirstResponder()
     }
 
@@ -205,7 +204,7 @@ class InteractiveCollectionView: NSCollectionView {
         if event.modifierFlags.contains(.command),
            event.keyCode == kVK_DownArrow {
             if !selectionIndexPaths.isEmpty {
-                interactionDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
+                interactionDelegate?.collectionView(self, didDoubleClickSelection: selectionIndexPaths)
             }
             return
         }

--- a/Sources/SelectableCollectionView/Views/InteractiveCollectionView.swift
+++ b/Sources/SelectableCollectionView/Views/InteractiveCollectionView.swift
@@ -23,20 +23,18 @@
 import AppKit
 import Carbon
 
-protocol CustomCollectionViewMenuDelegate: NSObject {
+protocol InteractiveCollectionViewDelegate: NSObject {
 
-    func customCollectionView(_ customCollectionView: CustomCollectionView, contextMenuForSelection selection: IndexSet) -> NSMenu?
-    func customCollectionView(_ customCollectionView: CustomCollectionView, didUpdateSelection selection: Set<IndexPath>)
-    func customCollectionView(_ customCollectionView: CustomCollectionView, didDoubleClickSelection selection: Set<IndexPath>)
-    func customCollectionView(_ customCollectionView: CustomCollectionView, didUpdateFocus isFirstResponder: Bool)
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView, contextMenuForSelection selection: IndexSet) -> NSMenu?
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateSelection selection: Set<IndexPath>)
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didDoubleClickSelection selection: Set<IndexPath>)
+    func customCollectionView(_ customCollectionView: InteractiveCollectionView, didUpdateFocus isFirstResponder: Bool)
 
 }
 
-// TODO: Rename to InteractiveCollectionView
-class CustomCollectionView: NSCollectionView {
+class InteractiveCollectionView: NSCollectionView {
 
-    // TODO: Rename
-    weak var menuDelegate: CustomCollectionViewMenuDelegate?
+    weak var interactionDelegate: InteractiveCollectionViewDelegate?
 
     var cursor: IndexPath?
 
@@ -71,11 +69,11 @@ class CustomCollectionView: NSCollectionView {
         } else {
             selectionIndexPaths = []
         }
-        menuDelegate?.customCollectionView(self, didUpdateSelection: selectionIndexPaths)
+        interactionDelegate?.customCollectionView(self, didUpdateSelection: selectionIndexPaths)
 
         // Get the menu for the current selection.
 #warning("TODO: Update to selectionIndexPaths")
-        if let menu = menuDelegate?.customCollectionView(self, contextMenuForSelection: selectionIndexes) {
+        if let menu = interactionDelegate?.customCollectionView(self, contextMenuForSelection: selectionIndexes) {
             return menu
         }
 
@@ -180,18 +178,18 @@ class CustomCollectionView: NSCollectionView {
 
         // Handle double-click.
         if event.clickCount > 1, !selectionIndexPaths.isEmpty {
-            menuDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
+            interactionDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
             return
         }
     }
 
     override func becomeFirstResponder() -> Bool {
-        menuDelegate?.customCollectionView(self, didUpdateFocus: true)
+        interactionDelegate?.customCollectionView(self, didUpdateFocus: true)
         return super.becomeFirstResponder()
     }
 
     override func resignFirstResponder() -> Bool {
-        menuDelegate?.customCollectionView(self, didUpdateFocus: false)
+        interactionDelegate?.customCollectionView(self, didUpdateFocus: false)
         return super.resignFirstResponder()
     }
 
@@ -207,7 +205,7 @@ class CustomCollectionView: NSCollectionView {
         if event.modifierFlags.contains(.command),
            event.keyCode == kVK_DownArrow {
             if !selectionIndexPaths.isEmpty {
-                menuDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
+                interactionDelegate?.customCollectionView(self, didDoubleClickSelection: selectionIndexPaths)
             }
             return
         }


### PR DESCRIPTION
This change also addresses a few todos and tidies up the class naming a little, bringing it in line with some of the implementation in Folders which was used as a prototype for this implementation.