### PR TITLE
fix: Updating selection and contents at the same time can leads to hangs

### DIFF
--- a/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
+++ b/Sources/SelectableCollectionView/Views/CollectionViewContainer.swift
@@ -175,7 +175,12 @@ public class CollectionViewContainer<Element: Hashable, Content: View>: NSView,
         let indexPaths = selection.compactMap { element in
             return dataSource?.indexPath(for: element)
         }
-        collectionView.selectionIndexPaths = Set(indexPaths)
+
+        // Updating the selection at the same time as the items seems to cause some form of loop or deadlock, so we
+        // break that by dispatching back to the main queue.
+        DispatchQueue.main.async {
+            self.collectionView.selectionIndexPaths = Set(indexPaths)
+        }
 
     }
 


### PR DESCRIPTION
I've noticed that it's possible to cause a hang when updating the contents and selection at the same time. This works around that by asynchronously dispatching the selection set back to the main queue to break the (assumed) dependency loop.